### PR TITLE
Expose Dispatch Router and example registry endpoints

### DIFF
--- a/hono/helm_chart/eclipse-hono-1.0.3/eclipse-hono/example/example-permissions.json
+++ b/hono/helm_chart/eclipse-hono-1.0.3/eclipse-hono/example/example-permissions.json
@@ -44,6 +44,18 @@
       {
         "operation": "device_con/*:*",
         "activities": [ "EXECUTE" ]
+      },
+      {
+        "resource": "control/*",
+        "activities": [ "READ", "WRITE" ]
+      },
+      {
+        "resource": "command/*",
+        "activities": [ "READ" ]
+      },
+      {
+        "resource": "command_response/*",
+        "activities": [ "WRITE" ]
       }
     ],
     "device-manager": [

--- a/hono/helm_chart/eclipse-hono-1.0.3/eclipse-hono/templates/dispatch-router/config/qdrouterd-with-artemis.yaml
+++ b/hono/helm_chart/eclipse-hono-1.0.3/eclipse-hono/templates/dispatch-router/config/qdrouterd-with-artemis.yaml
@@ -145,6 +145,20 @@
       }
   }],
 
+  ["vhost", {
+      "hostname": "io-fog",
+      "maxConnections": 50,
+      "groups": {
+        "$default": {
+          "remoteHosts": "*",
+          "maxSessions": 4,
+          "maxMessageSize": 131072,
+          "allowUserIdProxy": true,
+          "allowAnonymousSender": true
+        }
+      }
+  }],
+
   ["log", {
     "module": "DEFAULT",
     "enable": "info+"

--- a/hono/helm_chart/eclipse-hono-1.0.3/eclipse-hono/templates/hono-service-device-registry/hono-service-device-registry-ext-svc.yaml
+++ b/hono/helm_chart/eclipse-hono-1.0.3/eclipse-hono/templates/hono-service-device-registry/hono-service-device-registry-ext-svc.yaml
@@ -22,6 +22,14 @@ metadata:
   {{- end }}
 spec:
   ports:
+  - name: amqps
+    port: 5671
+    protocol: TCP
+    targetPort: amqps
+  - name: amqp
+    port: 5672
+    protocol: TCP
+    targetPort: amqp
   - name: http
     port: 28080
     protocol: TCP


### PR DESCRIPTION
The modifications in this PR will allow protocol adapters to connect to the Dispatch Router and example device registry from outside of the kubernetes cluster where Hono is installed.

The adapters' credentials will be exposed on the network if the non-TLS secured endpoints are used.