### PR TITLE
Expose health check port on network interfaces

### DIFF
--- a/hono/register.sh
+++ b/hono/register.sh
@@ -95,6 +95,8 @@ spec:
         value: dev
       - key: LOGGING_CONFIG
         value: classpath:logback-spring.xml
+      - key: HONO_HEALTH_CHECK_INSECURE_PORT_BIND_ADDRESS
+        value: "0.0.0.0"
       - key: HONO_HTTP_INSECURE_PORT_ENABLED
         value: true" > $ADAPTER_YAML_FILE
 


### PR DESCRIPTION
The adapter does not start up without a health check port being enabled.
This behavior is probably not desirable in a standalone Docker
environment.
It has been implemented with kubernetes as the deployment target in
mind.
See https://www.eclipse.org/hono/docs/admin-guide/monitoring-tracing-config/#health-check-server-configuration
for details.
