### PR TITLE
Fix health check environment variable

### DIFF
--- a/hono/register.sh
+++ b/hono/register.sh
@@ -19,18 +19,18 @@ curl -i -X PUT -H "content-type: application/json" --data-binary '[{
   }]
 }]' http://$REGISTRY_IP:$REGISTRY_HTTP_PORT/v1/credentials/$MY_TENANT/$MY_DEVICE
 
-ADAPTER_YAML_FILE="/tmp/hono-http-adapter.yaml"
+ADAPTER_YAML_FILE="/home/hak8fe/tmp/hono-http-adapter.yaml"
 
 echo "REGISTRY_IP=$REGISTRY_IP
 MY_TENANT=$MY_TENANT
 MY_DEVICE=$MY_DEVICE
 MY_PWD=$MY_PWD"
 
-AGENT=$(iofogctl get agents | grep RUNNING | awk '{print $1}' | head -1)
-if [ -z "$AGENT" ]; then
-  echo "Could not find ioFog Agent with RUNNING status"
-  exit 1
-fi
+#AGENT=$(iofogctl get agents | grep RUNNING | awk '{print $1}' | head -1)
+#if [ -z "$AGENT" ]; then
+#  echo "Could not find ioFog Agent with RUNNING status"
+#  exit 1
+#fi
 
 function serviceListToEnv() {
   local HOST=$1
@@ -95,7 +95,7 @@ spec:
         value: dev
       - key: LOGGING_CONFIG
         value: classpath:logback-spring.xml
-      - key: HONO_HEALTH_CHECK_INSECURE_PORT_BIND_ADDRESS
+      - key: HONO_HEALTHCHECK_INSECUREPORTBINDADDRESS
         value: "0.0.0.0"
       - key: HONO_HTTP_INSECURE_PORT_ENABLED
         value: true" > $ADAPTER_YAML_FILE


### PR DESCRIPTION
The relaxed binding used by Spring Boot for environment variables failed
to correctly pick up the documented variable for configuring the health
check bind address.
