### PR TITLE
Fix application deployment descriptor file name

### DIFF
--- a/hono/README.md
+++ b/hono/README.md
@@ -46,7 +46,7 @@ Again, make sure to replace the `my-ns` parameter value with the name of the nam
 used for your ioFog ECN.
 
 ```bash
-iofogctl deploy -f /tmp/hono-http-adapter.yaml -n my-ns
+iofogctl deploy -f /tmp/application.yaml -n my-ns
 ```
 
 ## Check out your new hotness

--- a/hono/register.sh
+++ b/hono/register.sh
@@ -162,7 +162,7 @@ function createApplicationYaml(){
       config:
         username: consumer@HONO
         password: verysecret
-        port: $ROUTER_PORT
+        port: 15672
         host: $ROUTER_IP
         queue: event/DEFAULT_TENANT
       images:


### PR DESCRIPTION
Also fixed amqp-to-iomessage container to connect to standard AMQP port
on back end dispatch router instead of the "internal" port that is used
by protocol adapters.